### PR TITLE
Add snapcraft.yaml

### DIFF
--- a/snap/snapcraft-gui.yaml
+++ b/snap/snapcraft-gui.yaml
@@ -1,6 +1,6 @@
 name: tokenpay
 version: "1.0"
-summary: TokenPay wallet
+summary: TokenPay wallet GUI
 description: TokenPay wallet
 grade: stable
 confinement: classic

--- a/snap/snapcraft-headless.yaml
+++ b/snap/snapcraft-headless.yaml
@@ -1,0 +1,78 @@
+# CLI only, no GUI. Managed to build this on a Raspberry Pi 3
+# as well. So this builds cleanly on armhf, and x86_64
+name: tokenpayd
+version: "1.0"
+summary: TokenPay wallet headless
+description: TokenPay wallet
+grade: stable
+confinement: classic
+apps:
+  tokenpayd:
+    command: bin/tokenpayd
+    environment:
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/local/lib
+    plugs:
+      - network
+      - network-bind
+parts:
+  boost:
+    # this needs to be built against the new openssl
+    plugin: nil
+    source: https://dl.bintray.com/boostorg/release/1.63.0/source/boost_1_63_0.tar.gz
+    build-packages:
+      - debhelper
+      - dpkg-dev
+      - dctrl-tools
+      - zlib1g-dev
+      - libbz2-dev
+      - libicu-dev
+      - mpi-default-dev
+      - bison
+      - flex
+      - docbook-to-man
+      - help2man
+      - xsltproc
+      - doxygen
+      - dh-python
+      - g++
+      - g++-5
+      - python
+      - python-all-dev
+      - python3
+      - python3-all-dev
+    build: |
+      ./bootstrap.sh --prefix=$SNAPCRAFT_PART_INSTALL/usr
+    install: |
+      ./bjam install -j4
+    after: [openssl]
+  openssl:
+    # tokenpay needs openssl 1.1 to build
+    plugin: nil
+    build: |
+      ./config --prefix=$SNAPCRAFT_PART_INSTALL/usr
+      make -j4
+    install: |
+      make install
+    source: https://github.com/openssl/openssl.git
+    source-type: git
+    source-branch: OpenSSL_1_1_0-stable
+  libevent:
+    # this needs to be built against the new openssl
+    plugin: autotools
+    source: https://github.com/libevent/libevent.git
+    source-type: git
+    source-branch: release-2.1.8-stable
+    after: [openssl]
+  tokenpay:
+    plugin: autotools
+    source-type: git
+    build-packages:
+      - libseccomp-dev
+      - libcap-dev
+      - pkg-config
+    stage-packages:
+      - zlib1g
+      - shared-mime-info
+    source: https://github.com/tokenpay/tokenpay
+    after: [libevent, boost]
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,124 @@
+name: tokenpay
+version: "1.0"
+summary: TokenPay wallet
+description: TokenPay wallet
+grade: stable
+confinement: classic
+apps:
+  tokenpay:
+    command: bin/tokenpay
+    environment:
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/local/lib
+    plugs:
+      - desktop
+      - wayland
+      - x11
+      - network
+      - network-bind
+  tokenpayd:
+    command: bin/tokenpayd
+    environment:
+      LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/local/lib
+    plugs:
+      - desktop
+      - wayland
+      - x11
+      - network
+      - network-bind
+parts:
+  boost:
+    # this needs to be built against the new openssl
+    plugin: nil
+    source: https://dl.bintray.com/boostorg/release/1.63.0/source/boost_1_63_0.tar.gz
+    build-packages:
+      - debhelper
+      - dpkg-dev
+      - dctrl-tools
+      - zlib1g-dev
+      - libbz2-dev
+      - libicu-dev
+      - mpi-default-dev
+      - bison
+      - flex
+      - docbook-to-man
+      - help2man
+      - xsltproc
+      - doxygen
+      - dh-python
+      - g++
+      - g++-5
+      - python
+      - python-all-dev
+      - python3
+      - python3-all-dev
+    build: |
+      ./bootstrap.sh --prefix=$SNAPCRAFT_PART_INSTALL/usr
+    install: |
+      ./bjam install -j8
+    after: [openssl]
+  openssl:
+    # tokenpay needs openssl 1.1 to build
+    plugin: nil
+    build: |
+      ./config --prefix=$SNAPCRAFT_PART_INSTALL/usr
+      make -j8
+    install: |
+      make install 
+    source: https://github.com/openssl/openssl.git
+    source-type: git
+    source-branch: OpenSSL_1_1_0-stable
+  libevent:
+    # this needs to be built against the new openssl
+    plugin: autotools
+    source: https://github.com/libevent/libevent.git
+    source-type: git
+    source-branch: release-2.1.8-stable
+    after: [openssl]
+  dummy:
+    # just a dummy part that simply adds the KDE neon repo. We need this
+    # to get a newer version of Qt5. The default one in ubuntu 16.04 segfaults
+    plugin: nil
+    build: |
+      apt-add-repository http://archive.neon.kde.org/user
+      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E6D4736255751E5D
+      apt-get update
+  tokenpay:
+    plugin: autotools
+    prepare: |
+      # upgrade the local packages. This should upgrade the Qt5 packages that
+      # were installed by the build-packages stanza. 
+      apt-get -y dist-upgrade
+    configflags:
+      - --enable-gui
+      - CPPFLAGS=-I$SNAPCRAFT_PART_INSTALL/usr/include/x86_64-linux-gnu/qt5/QtWebKitWidgets -I$SNAPCRAFT_STAGE/include -I$SNAPCRAFT_STAGE/usr/include -I$SNAPCRAFT_PART_INSTALL/usr/include/x86_64-linux-gnu/qt5/QtWebKit -I$SNAPCRAFT_PART_INSTALL/usr/include/x86_64-linux-gnu/qt5
+    source-type: git
+    build-packages:
+      - libqt5webkit5-dev
+      - libqt5webkit5
+      - libseccomp-dev
+      - libcap-dev
+      - pkg-config
+      - qt5-default
+      - qtchooser
+      - qttools5-dev-tools
+    stage-packages:
+      - hicolor-icon-theme
+      - zlib1g
+      - libgtk-3-bin
+      - libgtk-3-0
+      - libqt5core5a
+      - libqt5dbus5
+      - libqt5widgets5
+      - qt5-default
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - shared-mime-info
+      - libqt5webkit5
+      - libqt5gui5
+      - libqt5webkit5-dev
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+    source: https://github.com/tokenpay/tokenpay
+    after: [libevent, boost, dummy]


### PR DESCRIPTION
This adds a snapcraft.yaml that allows the automated build of a snap from the master branch of tokenpay.

A snap is a universal package format that will run on virtually any modern linux distribution. This should solve the problem of building installers or packages for multiple distributions, and allows you to publish the app on the snap store:

https://snapcraft.io/store

Note, that building a snap will fail, until a fix is committed for issues:

https://github.com/tokenpay/tokenpay/issues/1
https://github.com/tokenpay/tokenpay/issues/2
https://github.com/tokenpay/db4.8/issues/1

After these issues are addressed, you can build a snap on any Ubuntu machine by running these commands:

```bash
sudo snap install --classic snapcraft
cd tokenpay/snap
# use snapcraft-headless.yaml to only build the CLI version
# the cli version should be used if building on raspberry pi
ln -s snapcraft-gui.yaml snapcraft.yaml
# Add --no-parallel-builds if building on low powered low
# memory hardware
snapcraft cleanbuild
```

The build process is automated. Once finished you will have a resulting: ```tokenpay_1.0_amd64.snap``` or ```tokenpay_1.0_armhf.snap``` (depending on what architecture you built this on).

which can be installed with the following command:

```bash
sudo snap install --dangerous --classic tokenpay_1.0_amd64.snap
```

The dangerous flag is needed when installing packages from untrusted sources (not on the snap store)